### PR TITLE
Add markdown versions of all pages at <route>.md

### DIFF
--- a/build/content.go
+++ b/build/content.go
@@ -60,6 +60,9 @@ func (b *builder) collectPage(path string) (*pageInfo, error) {
 		return nil, nil
 	}
 
+	// Store raw markdown content with frontmatter for .md output
+	pg.MarkdownSource = content
+
 	pg.Content = template.HTML(renderMarkdown(mdContent))
 	pg.URL = b.determineURL(path)
 	pg.Slug = b.determineSlug(path)
@@ -100,6 +103,7 @@ func (b *builder) collectPage(path string) (*pageInfo, error) {
 		path:         path,
 		outputPath:   outputPath,
 		templateName: templateName,
+		pathType:     pathClass,
 	}, nil
 }
 

--- a/build/templates.go
+++ b/build/templates.go
@@ -110,6 +110,11 @@ func (b *builder) writeMarkdownPage(info pageInfo) error {
 		mdContent = info.page.MarkdownSource
 	}
 
+	// Ensure file ends with a newline
+	if len(mdContent) > 0 && mdContent[len(mdContent)-1] != '\n' {
+		mdContent = append(mdContent, '\n')
+	}
+
 	if err := os.MkdirAll(filepath.Dir(mdOutputPath), 0755); err != nil {
 		return fmt.Errorf("creating directory for %s: %w", mdOutputPath, err)
 	}

--- a/build/types.go
+++ b/build/types.go
@@ -7,14 +7,23 @@ import (
 
 // page represents a content page
 type page struct {
-	Title       string
-	Description string
-	Date        string
-	Content     template.HTML
-	URL         string
-	Slug        string
-	Template    string
-	Draft       bool
+	Title          string
+	Description    string
+	Date           string
+	Content        template.HTML
+	MarkdownSource []byte // Raw markdown content with frontmatter
+	URL            string
+	Slug           string
+	Template       string
+	Draft          bool
+}
+
+// MarkdownURL returns the URL for the markdown version of this page
+func (p *page) MarkdownURL() string {
+	if p.URL == "/" {
+		return "/index.md"
+	}
+	return p.URL + ".md"
 }
 
 // siteData holds global site data
@@ -100,6 +109,7 @@ type pageInfo struct {
 	path         string
 	outputPath   string
 	templateName string
+	pathType     pathType
 }
 
 // pathType represents the type of content path

--- a/templates/base.html
+++ b/templates/base.html
@@ -58,7 +58,7 @@
 
     <!-- Titles -->
     <title>{{ block "title" . }}sean lingren{{ end }}</title>
-    <meta name="description" content="{{ block "description" . }}sean lingren{{ end }}">
+    <meta name="description" content="{{ block " description" . }}sean lingren{{ end }}">
 
     <!-- Stylesheets -->
     <link rel="stylesheet" href="/css/style.css">
@@ -72,7 +72,7 @@
     {{ end }}
 
     <!-- Markdown Version -->
-    <link rel="alternate" type="text/markdown" title="Markdown version" href="{{ .Page.MarkdownURL }}">
+    <link rel="alternate" type="text/markdown" title="markdown version" href="{{ .Page.MarkdownURL }}">
   </head>
 
   <body>

--- a/templates/base.html
+++ b/templates/base.html
@@ -70,6 +70,9 @@
     <link rel="alternate" type="application/rss+xml" title="sean lingren - blog (rss)" href="/blog.xml">
     <link rel="alternate" type="application/atom+xml" title="sean lingren - blog (atom)" href="/blog.atom">
     {{ end }}
+
+    <!-- Markdown Version -->
+    <link rel="alternate" type="text/markdown" title="Markdown version" href="{{ .Page.MarkdownURL }}">
   </head>
 
   <body>


### PR DESCRIPTION
Generate a .md version for every page alongside the HTML output:
- /index.md, /journal.md, /blog.md, /blog/<post>.md

For pages with dynamic content (journal and blog index), the markdown
is generated with the full list of entries/posts. For all other pages,
the original markdown source with frontmatter is preserved.

Adds <link rel="alternate" type="text/markdown"> to all HTML pages
pointing to their markdown equivalent.