### PR TITLE
strip smid tracking param from journal urls

### DIFF
--- a/.github/workflows/journal.yml
+++ b/.github/workflows/journal.yml
@@ -29,6 +29,7 @@ jobs:
           clean_url=$(echo "$clean_url" | sed -E 's/[&?]_ga=[^&]*//g')
           clean_url=$(echo "$clean_url" | sed -E 's/[&?]_gl=[^&]*//g')
           clean_url=$(echo "$clean_url" | sed -E 's/[&?]__readwiseLocation=[^&]*//g')
+          clean_url=$(echo "$clean_url" | sed -E 's/[&?]smid=[^&]*//g')
 
           # clean up any leftover ? or & at the end
           clean_url=$(echo "$clean_url" | sed -E 's/[?&]$//')

--- a/journal/journal.txt
+++ b/journal/journal.txt
@@ -1961,7 +1961,7 @@
 1777838230 https://seangoedecke.com/staff-engineer-archetypes/
 1777838867 https://perfloop.ai/
 1777839393 https://lemire.me/blog/2026/04/27/you-can-beat-the-binary-search/
-1777842475 https://www.nytimes.com/2026/04/26/business/dwarkesh-patel-podcast-ai.html?smid=nytcore-ios-share
+1777842475 https://www.nytimes.com/2026/04/26/business/dwarkesh-patel-podcast-ai.html
 1777849273 https://getcasa.com/
 1778042077 https://planetscale.com/blog/transparency-in-benchmarking
 1778085643 https://ampcode.com/news/neo


### PR DESCRIPTION
## Summary
- Removed `?smid=nytcore-ios-share` from the recent NYT entry on line 1964 of `journal/journal.txt`
- Added `smid` to the tracking-param strip list in `.github/workflows/journal.yml` so future saves are cleaned automatically

## Test plan
- [ ] Trigger the `journal.yml` workflow with a NYT URL containing `?smid=nytcore-ios-share` and confirm it lands without the param


---
_Generated by [Claude Code](https://claude.ai/code/session_01PRKV6DcsR1PxaLrWqScngC)_